### PR TITLE
Orders to product menu

### DIFF
--- a/app/controllers/listed/figures_controller.rb
+++ b/app/controllers/listed/figures_controller.rb
@@ -14,5 +14,10 @@ class Listed::FiguresController < ApplicationController
       figure.user.id == current_user.id
     end
 
+    # collects all reviews that match the current logged in user's ID for display
+    @user_reviews = Review.all.select do |review|
+      review.reviewee.id == current_user.id
+    end
+
   end
 end

--- a/app/controllers/listed/figures_controller.rb
+++ b/app/controllers/listed/figures_controller.rb
@@ -18,6 +18,5 @@ class Listed::FiguresController < ApplicationController
     @user_reviews = Review.all.select do |review|
       review.reviewee.id == current_user.id
     end
-
   end
 end

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -2,22 +2,31 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="toggle"
 export default class extends Controller {
-  static targets = ["orderButton", "productButton"]
+  static targets = ["orderButton", "productButton", "reviewButton"]
 
+  // this hides product and order list when page loads
   connect() {
     console.log("Hello, Stimulus!", this.element);
     this.productButtonTarget.classList.add("d-none");
+    this.reviewButtonTarget.classList.add("d-none");
   }
 
+  // this hides the order button and shows the product button when the product button is clicked
   product() {
-    console.log("product!", this.element);
     this.orderButtonTarget.classList.add("d-none");
     this.productButtonTarget.classList.remove("d-none");
   }
 
+  // this hides the product button and shows the order button when the order button is clicked
   order() {
-    console.log("order!", this.element);
     this.productButtonTarget.classList.add("d-none");
     this.orderButtonTarget.classList.remove("d-none");
+  }
+
+  // this hides the buttons when the review button is clicked
+  review() {
+    this.productButtonTarget.classList.add("d-none");
+    this.orderButtonTarget.classList.add("d-none");
+    this.reviewButtonTarget.classList.remove("d-none");
   }
 }

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -2,14 +2,22 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="toggle"
 export default class extends Controller {
-  static targets = ["togglableElement"]
+  static targets = ["orderButton", "productButton"]
 
   connect() {
     console.log("Hello, Stimulus!", this.element);
+    this.productButtonTarget.classList.add("d-none");
   }
 
-  fire() {
-    console.log("Fire!", this.element);
-    this.togglableElementTarget.classList.toggle("d-none");
+  product() {
+    console.log("product!", this.element);
+    this.orderButtonTarget.classList.add("d-none");
+    this.productButtonTarget.classList.remove("d-none");
+  }
+
+  order() {
+    console.log("order!", this.element);
+    this.productButtonTarget.classList.add("d-none");
+    this.orderButtonTarget.classList.remove("d-none");
   }
 }

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -11,22 +11,24 @@ export default class extends Controller {
     this.reviewButtonTarget.classList.add("d-none");
   }
 
-  // this hides the order button and shows the product button when the product button is clicked
+  // hides other list except product list when product button is clicked
   product() {
     this.orderButtonTarget.classList.add("d-none");
     this.productButtonTarget.classList.remove("d-none");
+    this.reviewButtonTarget.classList.add("d-none");
   }
 
-  // this hides the product button and shows the order button when the order button is clicked
+  // hides other list except order list when order button is clicked
   order() {
-    this.productButtonTarget.classList.add("d-none");
     this.orderButtonTarget.classList.remove("d-none");
+    this.productButtonTarget.classList.add("d-none");
+    this.reviewButtonTarget.classList.add("d-none");
   }
 
-  // this hides the buttons when the review button is clicked
+  // this hides other list except review list when the review button is clicked
   review() {
-    this.productButtonTarget.classList.add("d-none");
     this.orderButtonTarget.classList.add("d-none");
+    this.productButtonTarget.classList.add("d-none");
     this.reviewButtonTarget.classList.remove("d-none");
   }
 }

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="toggle"
+export default class extends Controller {
+  static targets = ["togglableElement"]
+
+  connect() {
+    console.log("Hello, Stimulus!", this.element);
+  }
+
+  fire() {
+    console.log("Fire!", this.element);
+    this.togglableElementTarget.classList.toggle("d-none");
+  }
+}

--- a/app/views/listed/figures/_review_list.html.erb
+++ b/app/views/listed/figures/_review_list.html.erb
@@ -1,0 +1,14 @@
+<div class="container">
+  <h1>Reviews</h1>
+  <% @user_reviews.each do |review| %>
+    <div class="p-3 m-3 col-9 row">
+      <%= image_tag review.order.figure.photos.first, class: "col-3 rounded" if review.order.figure.photos.any? %>
+      <div class="col-6">
+        <p class="card-title">order number : <%= review.order.id %></p>
+        <p class="card-text">comment: "<%= review.comment %>"</p>
+        <p class="card-text">rating: <%= review.rating %></p>
+        <p class="card-text">buyer name: <%= review.order.buyer.username %> ID: <%= review.order.buyer_id %> </p>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/listed/figures/index.html.erb
+++ b/app/views/listed/figures/index.html.erb
@@ -1,13 +1,13 @@
-<div class="container">
+<div class="container" data-controller="toggle">
   <div class="row">
     <div class="card col-3 p-3">
-      <ul>
-        <li><%= link_to "Sale Orders", listed_figures_path  %></li>
-        <li>Products</li>
-        <li>Reviews</li>
+      <ul class="nav nav-pills flex-column mb-auto">
+        <li class="nav-link"><%= link_to "Sale Orders", listed_figures_path  %></li>
+        <li data-action="click->toggle#fire" class="nav-link">Products</li>
+        <li class="nav-link">Reviews</li>
       </ul>
     </div>
-    <div class=" col-9">
+    <div data-toggle-target="togglableElement" class=" col-9">
       <%= render "order_list" %>
     </div>
     <div class=" col-9">

--- a/app/views/listed/figures/index.html.erb
+++ b/app/views/listed/figures/index.html.erb
@@ -4,7 +4,7 @@
       <ul class="nav nav-pills flex-column mb-auto">
         <li data-action="click->toggle#order" class="nav-link">Sale Orders</li>
         <li data-action="click->toggle#product" class="nav-link">Products</li>
-        <li class="nav-link">Reviews</li>
+        <li data-action="click->toggle#review" class="nav-link">Reviews</li>
       </ul>
     </div>
     <div data-toggle-target="orderButton" class=" col-9">

--- a/app/views/listed/figures/index.html.erb
+++ b/app/views/listed/figures/index.html.erb
@@ -13,5 +13,8 @@
     <div data-toggle-target="productButton" class=" col-9">
       <%= render "product_list" %>
     </div>
+    <div data-toggle-target="reviewButton" class=" col-9">
+      <%= render "review_list" %>
+    </div>
   </div>
 </div>

--- a/app/views/listed/figures/index.html.erb
+++ b/app/views/listed/figures/index.html.erb
@@ -2,15 +2,15 @@
   <div class="row">
     <div class="card col-3 p-3">
       <ul class="nav nav-pills flex-column mb-auto">
-        <li class="nav-link"><%= link_to "Sale Orders", listed_figures_path  %></li>
-        <li data-action="click->toggle#fire" class="nav-link">Products</li>
+        <li data-action="click->toggle#order" class="nav-link">Sale Orders</li>
+        <li data-action="click->toggle#product" class="nav-link">Products</li>
         <li class="nav-link">Reviews</li>
       </ul>
     </div>
-    <div data-toggle-target="togglableElement" class=" col-9">
+    <div data-toggle-target="orderButton" class=" col-9">
       <%= render "order_list" %>
     </div>
-    <div class=" col-9">
+    <div data-toggle-target="productButton" class=" col-9">
       <%= render "product_list" %>
     </div>
   </div>


### PR DESCRIPTION
the dashboard menu is now working with JS stimulus, lets you toggle between order, product and review list.

<img width="728" alt="Screenshot 2024-07-19 at 5 28 36 PM" src="https://github.com/user-attachments/assets/1b220327-2e58-467e-b84a-2e5f15e8f57e">
<img width="719" alt="Screenshot 2024-07-19 at 5 28 44 PM" src="https://github.com/user-attachments/assets/892e994d-1d72-4590-8f67-7089bbc9c88f">
<img width="545" alt="Screenshot 2024-07-19 at 5 28 50 PM" src="https://github.com/user-attachments/assets/2c013e87-256b-4104-871e-de53ba61e258">
